### PR TITLE
Support sending deferred messages

### DIFF
--- a/residentSynth/residentSynth.js
+++ b/residentSynth/residentSynth.js
@@ -1734,9 +1734,16 @@ ResSynth.residentSynth = (function(window)
     };
 
     // WebMIDIAPI §6.4 MIDIOutput interface
-    // This synth does not support timestamps (05.11.2015)
-    ResidentSynth.prototype.send = function(messageData, ignoredTimestamp)
+    ResidentSynth.prototype.send = function(messageData, timestamp = 0)
     {
+        const timeout = timestamp - performance.now();
+
+        if (timeout > 0) {
+            setTimeout(() => this.send(messageData), timeout);
+
+            return;
+        }
+
         var
             command = messageData[0] & 0xF0,
             channel = messageData[0] & 0xF,


### PR DESCRIPTION
This PR adds support for the optional `timestamp` parameter. It uses `setTimeout()` to re-schedule the messages if necessary.

It's the most simple way I could think of to implement this functionality. However I think it would be more accurate to schedule everything using the Web Audio API.